### PR TITLE
Better abstractions for commands used by the makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,8 +44,8 @@ $(call XDG.define,DATA,.local/share)
 $(call XDG.define,CONFIG,.config)
 
 # Commands to use for directory and symbolic link creation.
-mkdir := mkdir -p
-ln := ln -snf
+mkdir ?= mkdir -p
+ln ?= ln -snf
 
 # Determines whether the given path exists and is a directory.
 # Only existing directories contain a "." entry.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -45,7 +45,7 @@ $(call XDG.define,CONFIG,.config)
 
 # Commands to use for directory and symbolic link creation.
 mkdir ?= mkdir -p $(1)
-ln ?= ln -snf
+ln ?= ln -snf $(1) $(2)
 
 # Determines whether the given path exists and is a directory.
 # Only existing directories contain a "." entry.
@@ -56,7 +56,7 @@ directory? = $(wildcard $(1)/.)
 ensure_directory_exists = $(if $(call directory?,$(1)),,$(call mkdir,$(1)))
 
 # Generates a command to link $(2) to $(1).
-link = $(ln) $(1) $(2)
+link = $(call ln,$(1),$(2))
 
 # Map files in $(XDG_CONFIG_HOME.dotfiles) to $(XDG_CONFIG_HOME).
 $(XDG_CONFIG_HOME)/% : $(XDG_CONFIG_HOME.dotfiles)/% force

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -44,7 +44,7 @@ $(call XDG.define,DATA,.local/share)
 $(call XDG.define,CONFIG,.config)
 
 # Commands to use for directory and symbolic link creation.
-mkdir ?= mkdir -p
+mkdir ?= mkdir -p $(1)
 ln ?= ln -snf
 
 # Determines whether the given path exists and is a directory.
@@ -53,7 +53,7 @@ directory? = $(wildcard $(1)/.)
 
 # Generates a command that creates the given directory.
 # Generates the empty string if the directory already exists.
-ensure_directory_exists = $(if $(call directory?,$(1)),,$(mkdir) $(1))
+ensure_directory_exists = $(if $(call directory?,$(1)),,$(call mkdir,$(1)))
 
 # Generates a command to link $(2) to $(1).
 link = $(ln) $(1) $(2)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -55,18 +55,18 @@ directory? = $(wildcard $(1)/.)
 # Generates the empty string if the directory already exists.
 ensure_directory_exists = $(if $(call directory?,$(1)),,$(call mkdir,$(1)))
 
-# Generates a command to link $(2) to $(1).
-link = $(call ln,$(1),$(2))
+# Generates a command to link $(1) to $(2).
+link = $(call ln,$(2),$(1))
 
 # Map files in $(XDG_CONFIG_HOME.dotfiles) to $(XDG_CONFIG_HOME).
 $(XDG_CONFIG_HOME)/% : $(XDG_CONFIG_HOME.dotfiles)/% force
 	$(call ensure_directory_exists,$(@D))
-	$(call link,$<,$@)
+	$(call link,$@,$<)
 
 # Map files in $(~) to $(HOME).
 ~/% : $(~)/% force
 	$(call ensure_directory_exists,$(@D))
-	$(call link,$<,$@)
+	$(call link,$@,$<)
 
 # Phony targets
 


### PR DESCRIPTION
The point of parameterizing the commands used by the makefile is to allow the user to replace them with other commands. Converting the mkdir and ln variables from simply expanded to conditionally assigned will allow the user to customize the directory and symbolic link creation commands.

The makefile assumes that:

 - Parent directories are created automatically `mkdir -p`
 - Symbolic links are created `ln -s`
 - Existing symbolic links `ln -nf`
   - Are not dereferenced if they point to a directory `ln -n`
   - Are overwritten by new links `ln -f`